### PR TITLE
Session 11: Thread Block

### DIFF
--- a/lib/common/extension/async_value_guard.dart
+++ b/lib/common/extension/async_value_guard.dart
@@ -1,0 +1,17 @@
+import 'dart:async';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+extension AsyncValueExt<T> on AsyncValue<T> {
+  /// 例外発生時にも前回の値を保持するguard関数
+  Future<AsyncValue<T>> preservedGuard(
+    Future<T> Function() future,
+  ) async {
+    try {
+      return AsyncValue<T>.data(await future());
+      // ignore: avoid_catches_without_on_clauses
+    } catch (e, st) {
+      return AsyncValue<T>.error(e, st).copyWithPrevious(this);
+    }
+  }
+}

--- a/lib/features/weather/data/weather_data_source.dart
+++ b/lib/features/weather/data/weather_data_source.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:isolate';
 
 import 'package:flutter_training/features/weather/model/fetch_weather_request.dart';
 import 'package:flutter_training/features/weather/model/fetch_weather_response.dart';
@@ -20,11 +21,15 @@ class WeatherDataSource {
   WeatherDataSource(this._yumemiWeather);
   final YumemiWeather _yumemiWeather;
 
-  FetchWeatherResponse fetchWeather(FetchWeatherRequest request) {
-    final jsonResponse = _yumemiWeather.fetchWeather(jsonEncode(request));
-    final weatherResponse = FetchWeatherResponse.fromJson(
-      jsonDecode(jsonResponse) as Map<String, dynamic>,
-    );
+  Future<FetchWeatherResponse> fetchWeather(FetchWeatherRequest request) async {
+    final weatherResponse = await Isolate.run(() async {
+      final response = _yumemiWeather.syncFetchWeather(
+        jsonEncode(request),
+      );
+      return FetchWeatherResponse.fromJson(
+        jsonDecode(response) as Map<String, dynamic>,
+      );
+    });
     return weatherResponse;
   }
 }

--- a/lib/features/weather/model/weather_error_type.dart
+++ b/lib/features/weather/model/weather_error_type.dart
@@ -6,3 +6,11 @@ enum WeatherErrorType {
   const WeatherErrorType(this.message);
   final String message;
 }
+
+class WeatherExcepiton implements Exception {
+  const WeatherExcepiton(this.type);
+  final WeatherErrorType type;
+
+  @override
+  String toString() => type.message;
+}

--- a/lib/features/weather/model/weather_error_type.dart
+++ b/lib/features/weather/model/weather_error_type.dart
@@ -6,11 +6,3 @@ enum WeatherErrorType {
   const WeatherErrorType(this.message);
   final String message;
 }
-
-class WeatherExcepiton implements Exception {
-  const WeatherExcepiton(this.type);
-  final WeatherErrorType type;
-
-  @override
-  String toString() => type.message;
-}

--- a/lib/features/weather/model/weather_exception.dart
+++ b/lib/features/weather/model/weather_exception.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_training/features/weather/model/weather_error_type.dart';
+
+class WeatherExcepiton implements Exception {
+  const WeatherExcepiton(this.type);
+  final WeatherErrorType type;
+
+  @override
+  String toString() => type.message;
+}

--- a/lib/features/weather/screen/weather_screen.dart
+++ b/lib/features/weather/screen/weather_screen.dart
@@ -19,6 +19,7 @@ class WeatherScreen extends HookConsumerWidget {
       // Call開始時にローディングを表示
       if (next.isLoading) {
         showLoadingOverlay(context: context);
+        return;
       }
       // Call終了時にローディングを閉じる
       if ((previous?.isLoading ?? false) && !next.isLoading) {

--- a/lib/features/weather/screen/weather_screen.dart
+++ b/lib/features/weather/screen/weather_screen.dart
@@ -29,8 +29,9 @@ class WeatherScreen extends HookConsumerWidget {
       if (previous.isLoading && !next.isLoading) {
         Navigator.of(context).pop();
         if (next.error != null) {
-          if (next.error is WeatherExcepiton) {
-            final errorType = (next.error! as WeatherExcepiton).type;
+          final error = next.error!;
+          if (error is WeatherExcepiton) {
+            final errorType = error.type;
             showErrorDialog(
               context: context,
               title: 'エラーが発生しました',
@@ -42,7 +43,7 @@ class WeatherScreen extends HookConsumerWidget {
             context: context,
             title: 'エラーが発生しました',
             message: '不明なエラーが発生しました。\n'
-                '${next.error}',
+                '$error',
           );
           return;
         }

--- a/lib/features/weather/screen/weather_screen.dart
+++ b/lib/features/weather/screen/weather_screen.dart
@@ -24,18 +24,27 @@ class WeatherScreen extends HookConsumerWidget {
       if (previous == null) {
         return;
       }
-      
+
       // Call終了時にローディングを閉じる
       if (previous.isLoading && !next.isLoading) {
         Navigator.of(context).pop();
-
-        if (next.asError != null) {
-          final errorType = (next.asError!.error as WeatherExcepiton).type;
+        if (next.error != null) {
+          if (next.error is WeatherExcepiton) {
+            final errorType = (next.error! as WeatherExcepiton).type;
+            showErrorDialog(
+              context: context,
+              title: 'エラーが発生しました',
+              message: errorType.message,
+            );
+            return;
+          }
           showErrorDialog(
             context: context,
             title: 'エラーが発生しました',
-            message: errorType.message,
+            message: '不明なエラーが発生しました。\n'
+                '${next.error}',
           );
+          return;
         }
       }
     });

--- a/lib/features/weather/screen/weather_screen.dart
+++ b/lib/features/weather/screen/weather_screen.dart
@@ -28,14 +28,13 @@ class WeatherScreen extends HookConsumerWidget {
       // Call終了時にローディングを閉じる
       if (previous.isLoading && !next.isLoading) {
         Navigator.of(context).pop();
-        if (next.error != null) {
-          final error = next.error!;
+        final error = next.error;
+        if (error != null) {
           if (error is WeatherExcepiton) {
-            final errorType = error.type;
             showErrorDialog(
               context: context,
               title: 'エラーが発生しました',
-              message: errorType.message,
+              message: error.type.message,
             );
             return;
           }

--- a/lib/features/weather/screen/weather_screen.dart
+++ b/lib/features/weather/screen/weather_screen.dart
@@ -22,7 +22,7 @@ class WeatherScreen extends HookConsumerWidget {
       }
       // Call終了時にローディングを閉じる
       if ((previous?.isLoading ?? false) && !next.isLoading) {
-        context.pop();
+        Navigator.of(context).pop();
 
         if (next.asError != null) {
           final errorType = (next.asError!.error as WeatherExcepiton).type;
@@ -97,7 +97,6 @@ class WeatherScreen extends HookConsumerWidget {
   Future<void> showLoadingOverlay({
     required BuildContext context,
   }) async {
-    log('show dialog');
     await showDialog<void>(
       barrierDismissible: false,
       context: context,

--- a/lib/features/weather/screen/weather_screen.dart
+++ b/lib/features/weather/screen/weather_screen.dart
@@ -97,6 +97,7 @@ class WeatherScreen extends HookConsumerWidget {
   Future<void> showLoadingOverlay({
     required BuildContext context,
   }) async {
+    log('show dialog');
     await showDialog<void>(
       barrierDismissible: false,
       context: context,

--- a/lib/features/weather/screen/weather_screen.dart
+++ b/lib/features/weather/screen/weather_screen.dart
@@ -21,8 +21,12 @@ class WeatherScreen extends HookConsumerWidget {
         showLoadingOverlay(context: context);
         return;
       }
+      if (previous == null) {
+        return;
+      }
+      
       // Call終了時にローディングを閉じる
-      if ((previous?.isLoading ?? false) && !next.isLoading) {
+      if (previous.isLoading && !next.isLoading) {
         Navigator.of(context).pop();
 
         if (next.asError != null) {

--- a/lib/features/weather/screen/weather_screen.dart
+++ b/lib/features/weather/screen/weather_screen.dart
@@ -3,7 +3,7 @@ import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_training/features/weather/components/weather_temperature_widget.dart';
-import 'package:flutter_training/features/weather/model/weather_error_type.dart';
+import 'package:flutter_training/features/weather/model/weather_exception.dart';
 import 'package:flutter_training/features/weather/viewmodel/weather_viewmodel.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';

--- a/lib/features/weather/use_case/weather_use_case.dart
+++ b/lib/features/weather/use_case/weather_use_case.dart
@@ -17,16 +17,16 @@ FetchWeatherUseCase fetchWeatherUseCase(FetchWeatherUseCaseRef ref) =>
     );
 
 class FetchWeatherUseCase extends UseCase<FetchWeatherRequest,
-    Result<FetchWeatherResponse, WeatherErrorType>> {
+    Future<Result<FetchWeatherResponse, WeatherErrorType>>> {
   FetchWeatherUseCase(this._dataSource);
   final WeatherDataSource _dataSource;
 
   @override
-  Result<FetchWeatherResponse, WeatherErrorType> call(
+  Future<Result<FetchWeatherResponse, WeatherErrorType>> call(
     FetchWeatherRequest param,
-  ) {
+  ) async {
     try {
-      return Result.success(_dataSource.fetchWeather(param));
+      return Result.success(await _dataSource.fetchWeather(param));
     } on YumemiWeatherError catch (e) {
       switch (e) {
         case YumemiWeatherError.unknown:

--- a/lib/features/weather/viewmodel/weather_viewmodel.dart
+++ b/lib/features/weather/viewmodel/weather_viewmodel.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_training/common/extension/async_value_guard.dart';
 import 'package:flutter_training/features/weather/model/fetch_weather_request.dart';
-import 'package:flutter_training/features/weather/model/weather_error_type.dart';
+import 'package:flutter_training/features/weather/model/weather_exception.dart';
 import 'package:flutter_training/features/weather/model/weather_view_model_state.dart';
 import 'package:flutter_training/features/weather/use_case/weather_use_case.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';

--- a/lib/features/weather/viewmodel/weather_viewmodel.g.dart
+++ b/lib/features/weather/viewmodel/weather_viewmodel.g.dart
@@ -23,12 +23,12 @@ final yumemiWeatherProvider = Provider<YumemiWeather>.internal(
 );
 
 typedef YumemiWeatherRef = ProviderRef<YumemiWeather>;
-String _$weatherViewModelHash() => r'4cd7f3c70d1261c6701435f309e6c766c853ba27';
+String _$weatherViewModelHash() => r'7da42fdd7f3480c6e78a4a24ddbc0e5a402052f9';
 
 /// See also [WeatherViewModel].
 @ProviderFor(WeatherViewModel)
 final weatherViewModelProvider = AutoDisposeNotifierProvider<WeatherViewModel,
-    Result<WeatherViewModelState, WeatherErrorType>>.internal(
+    AsyncValue<WeatherViewModelState?>>.internal(
   WeatherViewModel.new,
   name: r'weatherViewModelProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -39,5 +39,5 @@ final weatherViewModelProvider = AutoDisposeNotifierProvider<WeatherViewModel,
 );
 
 typedef _$WeatherViewModel
-    = AutoDisposeNotifier<Result<WeatherViewModelState, WeatherErrorType>>;
+    = AutoDisposeNotifier<AsyncValue<WeatherViewModelState?>>;
 // ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/test/features/weather/data/weather_data_source_test.dart
+++ b/test/features/weather/data/weather_data_source_test.dart
@@ -21,7 +21,7 @@ void main() {
   final dataSource = WeatherDataSource(api);
 
   // Act
-  FetchWeatherResponse act() => dataSource.fetchWeather(
+  Future<FetchWeatherResponse> act() => dataSource.fetchWeather(
         FetchWeatherRequest(
           area: 'London',
           date: DateTime(2000),
@@ -30,7 +30,7 @@ void main() {
 
   test(
     'Yumemi Weather APIを用いていることの確認',
-    () {
+    () async {
       // Arrange
       final expectedResponse = FetchWeatherResponse(
         weatherCondition: WeatherCondition.sunny,
@@ -38,7 +38,7 @@ void main() {
         maxTemperature: 20,
         minTemperature: 10,
       );
-      when(api.fetchWeather(any)).thenReturn(
+      when(api.syncFetchWeather(any)).thenReturn(
         jsonEncode(
           expectedResponse.toJson(),
         ),
@@ -46,7 +46,7 @@ void main() {
 
       // Assert
       expect(
-        act(),
+        await act(),
         expectedResponse,
       );
     },
@@ -55,7 +55,7 @@ void main() {
     '不正なRequest時にYumemiWeatherError.invalidParameterの例外を出す',
     () {
       // Arrange
-      when(api.fetchWeather(any)).thenThrow(
+      when(api.syncFetchWeather(any)).thenThrow(
         YumemiWeatherError.invalidParameter,
       );
       // Assert
@@ -71,7 +71,7 @@ void main() {
     'APIエラー発生時にYumemiWeatherError.unknownの例外を出す',
     () {
       // Arrange
-      when(api.fetchWeather(any)).thenThrow(
+      when(api.syncFetchWeather(any)).thenThrow(
         YumemiWeatherError.unknown,
       );
       // Assert

--- a/test/features/weather/screen/weather_screen_test.dart
+++ b/test/features/weather/screen/weather_screen_test.dart
@@ -15,21 +15,17 @@ import 'package:flutter_training/features/weather/model/weather_view_model_state
 import 'package:flutter_training/features/weather/screen/weather_screen.dart';
 import 'package:flutter_training/features/weather/use_case/weather_use_case.dart';
 import 'package:flutter_training/features/weather/viewmodel/weather_viewmodel.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../utils/display_size.dart';
 import '../viewmodel/weather_viewmodel_test.dart';
 
-class _WeatherTestScreen extends HookConsumerWidget {
+class _WeatherTestScreen extends ConsumerWidget {
   const _WeatherTestScreen();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    WidgetsBinding.instance.endOfFrame.then(
-      (_) => ref
-          .read(routerProvider)
-          .pushReplacement(const WeatherRoute().location),
-    );
     return MaterialApp.router(
       routerConfig: ref.watch(routerProvider),
     );
@@ -61,8 +57,17 @@ void main() {
   late ProviderScope providerScope;
 
   testWidgets('初期状態で、全てのWidgetが表示されていること', (tester) async {
-    providerScope = const ProviderScope(
-      child: _WeatherTestScreen(),
+    providerScope = ProviderScope(
+      overrides: [
+        // 初期ルートを変更
+        routerProvider.overrideWithValue(
+          GoRouter(
+            routes: $appRoutes,
+            initialLocation: const WeatherRoute().location,
+          ),
+        ),
+      ],
+      child: const _WeatherTestScreen(),
     );
     await tester.pumpWidget(providerScope);
     await tester.pumpAndSettle();
@@ -92,6 +97,13 @@ void main() {
                   minTemperature: 10,
                 ),
               ),
+            ),
+          ),
+          // 初期ルートを変更
+          routerProvider.overrideWithValue(
+            GoRouter(
+              routes: $appRoutes,
+              initialLocation: const WeatherRoute().location,
             ),
           ),
         ],
@@ -124,6 +136,13 @@ void main() {
               ),
             ),
           ),
+          // 初期ルートを変更
+          routerProvider.overrideWithValue(
+            GoRouter(
+              routes: $appRoutes,
+              initialLocation: const WeatherRoute().location,
+            ),
+          ),
         ],
         child: const _WeatherTestScreen(),
       );
@@ -154,6 +173,13 @@ void main() {
               ),
             ),
           ),
+          // 初期ルートを変更
+          routerProvider.overrideWithValue(
+            GoRouter(
+              routes: $appRoutes,
+              initialLocation: const WeatherRoute().location,
+            ),
+          ),
         ],
         child: const _WeatherTestScreen(),
       );
@@ -170,8 +196,17 @@ void main() {
     '初期状態で天気の画像は表示されていない',
     (tester) async {
       // Arrange
-      providerScope = const ProviderScope(
-        child: _WeatherTestScreen(),
+      providerScope = ProviderScope(
+        overrides: [
+          // 初期ルートを変更
+          routerProvider.overrideWithValue(
+            GoRouter(
+              routes: $appRoutes,
+              initialLocation: const WeatherRoute().location,
+            ),
+          ),
+        ],
+        child: const _WeatherTestScreen(),
       );
       await tester.pumpWidget(providerScope);
       // Act
@@ -201,6 +236,13 @@ void main() {
                   minTemperature: 10,
                 ),
               ),
+            ),
+          ),
+          // 初期ルートを変更
+          routerProvider.overrideWithValue(
+            GoRouter(
+              routes: $appRoutes,
+              initialLocation: const WeatherRoute().location,
             ),
           ),
         ],
@@ -234,6 +276,13 @@ void main() {
               ),
             ),
           ),
+          // 初期ルートを変更
+          routerProvider.overrideWithValue(
+            GoRouter(
+              routes: $appRoutes,
+              initialLocation: const WeatherRoute().location,
+            ),
+          ),
         ],
         child: const _WeatherTestScreen(),
       );
@@ -265,6 +314,13 @@ void main() {
           fetchWeatherUseCaseProvider.overrideWithValue(
             mockUseCase,
           ),
+          // 初期ルートを変更
+          routerProvider.overrideWithValue(
+            GoRouter(
+              routes: $appRoutes,
+              initialLocation: const WeatherRoute().location,
+            ),
+          ),
         ],
         child: const _WeatherTestScreen(),
       );
@@ -272,8 +328,7 @@ void main() {
       await tester.pumpAndSettle();
       // Act
       await tester.tap(find.text('Reload'));
-      // pumpAndSettleだとタイムアウトしてしまうので pumpにする
-      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pumpAndSettle();
       // Assert
       expect(find.byType(AlertDialog), findsOneWidget);
       expect(find.text('エラーが発生しました'), findsOneWidget);
@@ -298,6 +353,13 @@ void main() {
       providerScope = ProviderScope(
         overrides: [
           fetchWeatherUseCaseProvider.overrideWithValue(mockUseCase),
+          // 初期ルートを変更
+          routerProvider.overrideWithValue(
+            GoRouter(
+              routes: $appRoutes,
+              initialLocation: const WeatherRoute().location,
+            ),
+          ),
         ],
         child: const _WeatherTestScreen(),
       );

--- a/test/features/weather/screen/weather_screen_test.dart
+++ b/test/features/weather/screen/weather_screen_test.dart
@@ -278,4 +278,36 @@ void main() {
       expect(find.text(WeatherErrorType.unknown.message), findsOneWidget);
     },
   );
+  testWidgets(
+    '特定の条件で、読み込み中のダイアログが表示される',
+    (tester) async {
+      // Arrange
+      final mockUseCase = MockWeatherUseCase()
+        ..result(
+          Future.value(
+            const Result<FetchWeatherResponse, WeatherErrorType>.failure(
+              WeatherErrorType.unknown,
+            ),
+          ),
+        );
+      providerScope = ProviderScope(
+        overrides: [
+          fetchWeatherUseCaseProvider.overrideWithValue(
+            mockUseCase,
+          ),
+        ],
+        child: const _WeatherTestScreen(),
+      );
+      await tester.pumpWidget(providerScope);
+      await tester.pumpAndSettle();
+      // Act
+      await tester.tap(find.text('Reload'));
+      // pumpAndSettleだとタイムアウトしてしまうので pumpにする
+      await tester.pump(const Duration(milliseconds: 100));
+      // Assert
+      expect(find.byType(AlertDialog), findsOneWidget);
+      expect(find.text('エラーが発生しました'), findsOneWidget);
+      expect(find.text(WeatherErrorType.unknown.message), findsOneWidget);
+    },
+  );
 }

--- a/test/features/weather/screen/weather_screen_test.dart
+++ b/test/features/weather/screen/weather_screen_test.dart
@@ -310,7 +310,7 @@ void main() {
       // Completerで結果を返していないので AsyncLoadingなはず
       expect(
         find.byType(CircularProgressIndicator),
-        findsWidgets,
+        findsOneWidget,
       );
     },
   );

--- a/test/features/weather/screen/weather_screen_test.dart
+++ b/test/features/weather/screen/weather_screen_test.dart
@@ -2,27 +2,34 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_training/common/model/result.dart';
+import 'package:flutter_training/common/provider/router_provider.dart';
+import 'package:flutter_training/constants/route.dart';
 import 'package:flutter_training/features/weather/components/weather_icon_widget.dart';
 import 'package:flutter_training/features/weather/components/weather_temperature_widget.dart';
 import 'package:flutter_training/features/weather/model/fetch_weather_response.dart';
 import 'package:flutter_training/features/weather/model/weather_condition.dart';
 import 'package:flutter_training/features/weather/model/weather_error_type.dart';
+import 'package:flutter_training/features/weather/model/weather_view_model_state.dart';
 import 'package:flutter_training/features/weather/screen/weather_screen.dart';
 import 'package:flutter_training/features/weather/use_case/weather_use_case.dart';
+import 'package:flutter_training/features/weather/viewmodel/weather_viewmodel.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../utils/display_size.dart';
 import '../viewmodel/weather_viewmodel_test.dart';
 
-class _WeatherTestScreen extends StatelessWidget {
+class _WeatherTestScreen extends HookConsumerWidget {
   const _WeatherTestScreen();
 
   @override
-  Widget build(BuildContext context) {
-    return const ProviderScope(
-      child: MaterialApp(
-        home: WeatherScreen(),
-      ),
+  Widget build(BuildContext context, WidgetRef ref) {
+    WidgetsBinding.instance.endOfFrame.then(
+      (_) => ref
+          .read(routerProvider)
+          .pushReplacement(const WeatherRoute().location),
+    );
+    return MaterialApp.router(
+      routerConfig: ref.watch(routerProvider),
     );
   }
 }
@@ -37,20 +44,13 @@ Finder findSvgImage(String assetName) {
   );
 }
 
-MockWeatherUseCase createMockUseCase({
-  required WeatherCondition expectedCondition,
-}) =>
-    MockWeatherUseCase()
-      ..result(
-        Result.success(
-          FetchWeatherResponse(
-            weatherCondition: expectedCondition,
-            date: DateTime(2000),
-            maxTemperature: 30,
-            minTemperature: 10,
-          ),
-        ),
-      );
+class _FakeWeatherViewModel extends WeatherViewModel {
+  _FakeWeatherViewModel(this.initialState);
+  final AsyncValue<WeatherViewModelState?> initialState;
+
+  @override
+  AsyncValue<WeatherViewModelState?> build() => initialState;
+}
 
 void main() {
   setUp(setDisplaySize);
@@ -59,7 +59,11 @@ void main() {
   late ProviderScope providerScope;
 
   testWidgets('初期状態で、全てのWidgetが表示されていること', (tester) async {
-    await tester.pumpWidget(const _WeatherTestScreen());
+    providerScope = const ProviderScope(
+      child: _WeatherTestScreen(),
+    );
+    await tester.pumpWidget(providerScope);
+    await tester.pumpAndSettle();
     expect(find.byType(WeatherScreen), findsOneWidget);
 
     expect(find.byType(WeatherTemperatureWidget), findsOneWidget);
@@ -77,17 +81,21 @@ void main() {
       const weatherCondition = WeatherCondition.sunny;
       providerScope = ProviderScope(
         overrides: [
-          fetchWeatherUseCaseProvider.overrideWithValue(
-            createMockUseCase(
-              expectedCondition: weatherCondition,
+          weatherViewModelProvider.overrideWith(
+            () => _FakeWeatherViewModel(
+              const AsyncData(
+                WeatherViewModelState(
+                  weatherCondition: weatherCondition,
+                  maxTemperature: 30,
+                  minTemperature: 10,
+                ),
+              ),
             ),
           ),
         ],
         child: const _WeatherTestScreen(),
       );
       await tester.pumpWidget(providerScope);
-      // Act
-      await tester.tap(find.text('Reload'));
       await tester.pumpAndSettle();
       // Assert
       expect(
@@ -103,15 +111,21 @@ void main() {
       const weatherCondition = WeatherCondition.cloudy;
       providerScope = ProviderScope(
         overrides: [
-          fetchWeatherUseCaseProvider.overrideWithValue(
-            createMockUseCase(expectedCondition: weatherCondition),
+          weatherViewModelProvider.overrideWith(
+            () => _FakeWeatherViewModel(
+              const AsyncData(
+                WeatherViewModelState(
+                  weatherCondition: weatherCondition,
+                  maxTemperature: 30,
+                  minTemperature: 10,
+                ),
+              ),
+            ),
           ),
         ],
         child: const _WeatherTestScreen(),
       );
       await tester.pumpWidget(providerScope);
-      // Act
-      await tester.tap(find.text('Reload'));
       await tester.pumpAndSettle();
       // Assert
       expect(
@@ -127,15 +141,21 @@ void main() {
       const weatherCondition = WeatherCondition.rainy;
       providerScope = ProviderScope(
         overrides: [
-          fetchWeatherUseCaseProvider.overrideWithValue(
-            createMockUseCase(expectedCondition: weatherCondition),
+          weatherViewModelProvider.overrideWith(
+            () => _FakeWeatherViewModel(
+              const AsyncData(
+                WeatherViewModelState(
+                  weatherCondition: weatherCondition,
+                  maxTemperature: 30,
+                  minTemperature: 10,
+                ),
+              ),
+            ),
           ),
         ],
         child: const _WeatherTestScreen(),
       );
       await tester.pumpWidget(providerScope);
-      // Act
-      await tester.tap(find.text('Reload'));
       await tester.pumpAndSettle();
       // Assert
       expect(
@@ -170,17 +190,21 @@ void main() {
       // Arrange
       providerScope = ProviderScope(
         overrides: [
-          fetchWeatherUseCaseProvider.overrideWithValue(
-            createMockUseCase(
-              expectedCondition: WeatherCondition.sunny,
+          weatherViewModelProvider.overrideWith(
+            () => _FakeWeatherViewModel(
+              const AsyncData(
+                WeatherViewModelState(
+                  weatherCondition: WeatherCondition.cloudy,
+                  maxTemperature: 30,
+                  minTemperature: 10,
+                ),
+              ),
             ),
           ),
         ],
         child: const _WeatherTestScreen(),
       );
       await tester.pumpWidget(providerScope);
-      // Act
-      await tester.tap(find.text('Reload'));
       await tester.pumpAndSettle();
       // Assert
       expect(find.byType(WeatherTemperatureWidget), findsOneWidget);
@@ -197,24 +221,28 @@ void main() {
       // Arrange
       providerScope = ProviderScope(
         overrides: [
-          fetchWeatherUseCaseProvider.overrideWithValue(
-            createMockUseCase(
-              expectedCondition: WeatherCondition.sunny,
+          weatherViewModelProvider.overrideWith(
+            () => _FakeWeatherViewModel(
+              const AsyncData(
+                WeatherViewModelState(
+                  weatherCondition: WeatherCondition.cloudy,
+                  maxTemperature: 30,
+                  minTemperature: 10,
+                ),
+              ),
             ),
           ),
         ],
         child: const _WeatherTestScreen(),
       );
       await tester.pumpWidget(providerScope);
-      // Act
-      await tester.tap(find.text('Reload'));
       await tester.pumpAndSettle();
       // Assert
       expect(find.byType(WeatherTemperatureWidget), findsOneWidget);
       final weatherTemperatureWidget = tester.widget<WeatherTemperatureWidget>(
         find.byType(WeatherTemperatureWidget),
       );
-      expect(weatherTemperatureWidget.maxTemperature, 30);
+      expect(weatherTemperatureWidget.minTemperature, 10);
       expect(find.text('10°C'), findsOneWidget);
     },
   );
@@ -224,8 +252,10 @@ void main() {
       // Arrange
       final mockUseCase = MockWeatherUseCase()
         ..result(
-          const Result.failure(
-            WeatherErrorType.unknown,
+          Future.value(
+            const Result<FetchWeatherResponse, WeatherErrorType>.failure(
+              WeatherErrorType.unknown,
+            ),
           ),
         );
       providerScope = ProviderScope(
@@ -237,9 +267,11 @@ void main() {
         child: const _WeatherTestScreen(),
       );
       await tester.pumpWidget(providerScope);
+      await tester.pumpAndSettle();
       // Act
       await tester.tap(find.text('Reload'));
-      await tester.pumpAndSettle();
+      // pumpAndSettleだとタイムアウトしてしまうので pumpにする
+      await tester.pump(const Duration(milliseconds: 100));
       // Assert
       expect(find.byType(AlertDialog), findsOneWidget);
       expect(find.text('エラーが発生しました'), findsOneWidget);

--- a/test/features/weather/use_case/weather_use_case_test.mocks.dart
+++ b/test/features/weather/use_case/weather_use_case_test.mocks.dart
@@ -3,10 +3,12 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:async' as _i4;
+
 import 'package:flutter_training/features/weather/data/weather_data_source.dart'
     as _i3;
 import 'package:flutter_training/features/weather/model/fetch_weather_request.dart'
-    as _i4;
+    as _i5;
 import 'package:flutter_training/features/weather/model/fetch_weather_response.dart'
     as _i2;
 import 'package:mockito/mockito.dart' as _i1;
@@ -38,25 +40,28 @@ class _FakeFetchWeatherResponse_0 extends _i1.SmartFake
 /// See the documentation for Mockito's code generation for more information.
 class MockWeatherDataSource extends _i1.Mock implements _i3.WeatherDataSource {
   @override
-  _i2.FetchWeatherResponse fetchWeather(_i4.FetchWeatherRequest? request) =>
+  _i4.Future<_i2.FetchWeatherResponse> fetchWeather(
+          _i5.FetchWeatherRequest? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchWeather,
           [request],
         ),
-        returnValue: _FakeFetchWeatherResponse_0(
+        returnValue: _i4.Future<_i2.FetchWeatherResponse>.value(
+            _FakeFetchWeatherResponse_0(
           this,
           Invocation.method(
             #fetchWeather,
             [request],
           ),
-        ),
-        returnValueForMissingStub: _FakeFetchWeatherResponse_0(
+        )),
+        returnValueForMissingStub: _i4.Future<_i2.FetchWeatherResponse>.value(
+            _FakeFetchWeatherResponse_0(
           this,
           Invocation.method(
             #fetchWeather,
             [request],
           ),
-        ),
-      ) as _i2.FetchWeatherResponse);
+        )),
+      ) as _i4.Future<_i2.FetchWeatherResponse>);
 }

--- a/test/features/weather/viewmodel/weather_viewmodel_test.dart
+++ b/test/features/weather/viewmodel/weather_viewmodel_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_training/features/weather/model/fetch_weather_request.da
 import 'package:flutter_training/features/weather/model/fetch_weather_response.dart';
 import 'package:flutter_training/features/weather/model/weather_condition.dart';
 import 'package:flutter_training/features/weather/model/weather_error_type.dart';
+import 'package:flutter_training/features/weather/model/weather_exception.dart';
 import 'package:flutter_training/features/weather/model/weather_view_model_state.dart';
 import 'package:flutter_training/features/weather/use_case/weather_use_case.dart';
 import 'package:flutter_training/features/weather/viewmodel/weather_viewmodel.dart';


### PR DESCRIPTION
## 課題

close #24 

## 対応箇所

- [x] 使用する API を `fetchWeather()` から `syncFetchWeather()` に変更する
- [x] API の処理が戻るまで [CircularProgressIndicator] を表示する
---
- [x] APIの変更に合わせてUnit Test・Widget Testの修正


## 動作

| expected | actual(iPhone 14 Pro iOS 16.4) |
|----------| --------   |
| ![expected]     | ![actual] |

[expected]: https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/thread_block/demo.gif?raw=true
[actual]: https://github.com/YumNumm/flutter-training/assets/73390859/5e6638c5-5ed0-497f-9fc4-5477f014340f